### PR TITLE
FIx Cameraman Upload

### DIFF
--- a/app/Http/Controllers/CameramanController.php
+++ b/app/Http/Controllers/CameramanController.php
@@ -74,14 +74,12 @@ class CameramanController extends Controller
     public function upload(PostEpisodeVideosRequest $req)
     {
         $payload = $req->validated();
-        foreach ($payload->videos as $video) {
-            $metadata = new DriveFile(['name' => $video->attachment->getClientOriginalName()]);
-            $file = $this->driveService->files->create($metadata, [
-                'data' => $video->attachment,
-                'fields' => 'id',
-            ]);
-            dd($file->id);
-        }
+        $metadata = new DriveFile(['name' => $payload['videos']['attachment']->getClientOriginalName()]);
+        $file = $this->driveService->files->create($metadata, [
+            'data' => $payload['videos']['attachment'],
+            'fields' => 'id',
+        ]);
+        dd($file->id);
     }
 
     public function createEpisode(PostEpisodeRequest $req)

--- a/app/Http/Controllers/CameramanController.php
+++ b/app/Http/Controllers/CameramanController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Google\Client;
 use Inertia\Inertia;
+use App\Models\Video;
 use Inertia\Response;
 use App\Models\Episode;
 use App\Models\Program;
@@ -11,6 +12,7 @@ use Google\Service\Drive;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Google\Service\Drive\DriveFile;
+use Illuminate\Http\RedirectResponse;
 use App\Http\Requests\PostEpisodeRequest;
 use Illuminate\Database\Query\JoinClause;
 use App\Http\Requests\PostEpisodeVideosRequest;
@@ -71,18 +73,22 @@ class CameramanController extends Controller
     }
 
     #TODO: implement feature
-    public function upload(PostEpisodeVideosRequest $req)
+    public function upload(PostEpisodeVideosRequest $req): RedirectResponse
     {
         $payload = $req->validated();
-        $metadata = new DriveFile(['name' => $payload['videos']['attachment']->getClientOriginalName()]);
+        $metadata = new DriveFile(['name' => $payload->attachment->getClientOriginalName()]);
         $file = $this->driveService->files->create($metadata, [
-            'data' => $payload['videos']['attachment'],
+            'data' => $payload->attachment,
             'fields' => 'id',
         ]);
-        dd($file->id);
+        Video::create([
+            'episode_id' => $payload->episode_id,
+            'object_id' => $file->id,
+        ]);
+        return back();
     }
 
-    public function createEpisode(PostEpisodeRequest $req)
+    public function createEpisode(PostEpisodeRequest $req): RedirectResponse
     {
         $payload = $req->validated();
         Episode::create($payload);

--- a/app/Http/Controllers/CameramanController.php
+++ b/app/Http/Controllers/CameramanController.php
@@ -76,13 +76,13 @@ class CameramanController extends Controller
     public function upload(PostEpisodeVideosRequest $req): RedirectResponse
     {
         $payload = $req->validated();
-        $metadata = new DriveFile(['name' => $payload->attachment->getClientOriginalName()]);
+        $metadata = new DriveFile(['name' => $payload['attachment']->getClientOriginalName()]);
         $file = $this->driveService->files->create($metadata, [
-            'data' => $payload->attachment,
+            'data' => $payload['attachment'],
             'fields' => 'id',
         ]);
         Video::create([
-            'episode_id' => $payload->episode_id,
+            'episode_id' => $payload['episode_id'],
             'object_id' => $file->id,
         ]);
         return back();

--- a/app/Http/Requests/PostEpisodeVideosRequest.php
+++ b/app/Http/Requests/PostEpisodeVideosRequest.php
@@ -15,9 +15,8 @@ class PostEpisodeVideosRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'videos' => ['required', 'array:episode_id,attachment'],
-            'videos.episode_id' => ['required', 'integer', 'numeric'],
-            'videos.attachment' => ['required', File::types(['mp4','mkv','mov'])],
+            'episode_id' => ['required', 'integer', 'numeric'],
+            'attachment' => ['required', File::types(['mp4','mkv','mov', 'webm'])],
         ];
     }
 }

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -10,6 +10,11 @@ class Video extends Model
 {
     use HasFactory;
 
+    protected $fillable = [
+        'episode_id',
+        'object_id'
+    ];
+
     public function users(): BelongsToMany
     {
         return $this->belongsToMany(User::class);

--- a/resources/js/Components/Cameraman/UploadVideoForm/index.tsx
+++ b/resources/js/Components/Cameraman/UploadVideoForm/index.tsx
@@ -13,7 +13,7 @@ type FormValues = {
   files: FileList;
 };
 
-const UploadVideoForm: React.FC<UploadVideoFormProps> = ({ episodeNumber }) => {
+const UploadVideoForm = ({ episodeNumber }: UploadVideoFormProps) => {
   const [selectedEpisode, setSelectedEpisode] = useState<number | null>(1);
   const { register, handleSubmit, setValue } = useForm<FormValues>({
     defaultValues: {
@@ -21,17 +21,14 @@ const UploadVideoForm: React.FC<UploadVideoFormProps> = ({ episodeNumber }) => {
       files: undefined,
     },
   });
-
   const { uploadVideo, isLoading, error } = useUploadEpisodeVideo();
 
   const onSubmit = async (data: FormValues) => {
     if (data.files && data.files.length > 0) {
-        console.log(data.files[0])
       const result = await uploadVideo({
         episode_id: data.episode,
         attachment: data.files[0],
       });
-
       if (result && result.success) {
         console.log('Video uploaded successfully:', result.file_id);
       }

--- a/resources/js/Components/Form/FileUpload/index.tsx
+++ b/resources/js/Components/Form/FileUpload/index.tsx
@@ -1,5 +1,5 @@
 import Button from '@/Components/Shared/Button';
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef } from 'react';
 import { useDropzone, FileRejection, DropEvent } from 'react-dropzone';
 
 type FileUploadProps = {
@@ -21,6 +21,7 @@ const FileUpload = ({
 }: FileUploadProps) => {
     const [previews, setPreviews] = useState<PreviewInfo[]>([]);
     const [rejected, setRejected] = useState<FileRejection[]>([]);
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
 
     const onDrop = useCallback(
         (acceptedFiles: File[], fileRejections: FileRejection[], event: DropEvent) => {
@@ -42,7 +43,7 @@ const FileUpload = ({
                 setRejected((previousFiles) => [...previousFiles, ...fileRejections]);
             }
         },
-        [previews, setValue, register]
+        [previews, setValue]
     );
 
     const {
@@ -58,6 +59,12 @@ const FileUpload = ({
         multiple: true,
     });
 
+    const handleButtonClick = () => {
+        if (fileInputRef.current) {
+            fileInputRef.current.click();
+        }
+    };
+
     return (
         <div>
             <div className="w-full min-h-[216px] h-fit p-3 mb-2 rounded-md border border-solid border-grey-300">
@@ -65,7 +72,11 @@ const FileUpload = ({
                     {...getRootProps()}
                     className={`${isDragActive ? 'bg-info-200' : ''} w-full min-h-[inherit] border border-dashed border-grey-300 rounded-sm flex justify-center items-center p-6 ease-in-out duration-300`}
                 >
-                    <input {...getInputProps()} {...register('files')} />
+                    <input
+                        {...getInputProps()}
+                        {...register('files')}
+                        ref={fileInputRef}
+                    />
                     {isDragActive ? (
                         <p className="body-2 text-secondary-text">Lepas file disini...</p>
                     ) : (
@@ -78,6 +89,7 @@ const FileUpload = ({
                                 color="Primary"
                                 width="Fit"
                                 size="Large"
+                                onClick={handleButtonClick}
                             />
                             <p className="body-2 text-secondary-text">
                                 Atau tarik dan lepas file di sini untuk menambahkannya.

--- a/resources/js/repositories/Cameraman/useUploadVideo.tsx
+++ b/resources/js/repositories/Cameraman/useUploadVideo.tsx
@@ -14,11 +14,13 @@ const useUploadEpisodeVideo = () => {
   const uploadVideo = async ({ episode_id, attachment }: IPayloadUploadVideoEpisode): Promise<IUploadEpisodeVideoResponse | null> => {
     console.log(attachment);
     setIsLoading(true);
+
+    console.log(attachment instanceof File);
     setError(null);
 
     const formData = new FormData();
-    formData.append('videos[episode_id]', episode_id.toString());
-    formData.append('videos[attachment]', attachment);
+    formData.append('episode_id', episode_id.toString());
+    formData.append('attachment', attachment);
 
 
     try {

--- a/resources/js/repositories/Cameraman/useUploadVideo.tsx
+++ b/resources/js/repositories/Cameraman/useUploadVideo.tsx
@@ -12,12 +12,14 @@ const useUploadEpisodeVideo = () => {
   const [error, setError] = useState<string | null>(null);
 
   const uploadVideo = async ({ episode_id, attachment }: IPayloadUploadVideoEpisode): Promise<IUploadEpisodeVideoResponse | null> => {
+    console.log(attachment);
     setIsLoading(true);
     setError(null);
 
     const formData = new FormData();
     formData.append('videos[episode_id]', episode_id.toString());
     formData.append('videos[attachment]', attachment);
+
 
     try {
       const response = await axios.post<IUploadEpisodeVideoResponse>('/api/v1/videos', formData, {


### PR DESCRIPTION
### Changes Made

- Remove `foreach` in `CameramanController->upload `
```php
    public function upload(PostEpisodeVideosRequest $req)
    {
        $payload = $req->validated();
        $metadata = new DriveFile(['name' => $payload['videos']['attachment']->getClientOriginalName()]);
        $file = $this->driveService->files->create($metadata, [
            'data' => $payload['videos']['attachment'],
            'fields' => 'id',
        ]);
        dd($file->id);
    }
``` 
- Fix Upload Button in Dropzone

### UI
![image](https://github.com/user-attachments/assets/96907a6a-f550-44d6-ad6f-75dfa33a2982)
